### PR TITLE
Add curl command for native upload support in CI

### DIFF
--- a/images/zenko-releng/Dockerfile
+++ b/images/zenko-releng/Dockerfile
@@ -1,8 +1,8 @@
-FROM docker:17.05.0-ce-git
+FROM docker:17.09.0-ce-git
 
 ENV GOPATH /go
 
-RUN apk add --no-cache nodejs make jq wget ca-certificates alpine-sdk python-dev libffi-dev openssl-dev py2-pip go && \
+RUN apk add --no-cache nodejs make jq wget ca-certificates alpine-sdk python-dev libffi-dev openssl-dev py2-pip go curl && \
     npm install -g @commitlint/cli @commitlint/config-conventional conventional-commits-parser semver && \
     go get -u github.com/aktau/github-release && \
     wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.8.1-linux-amd64.tar.gz && \


### PR DESCRIPTION
The step `Upload` on Eve requires curl to work. It isn't installed by default in this image.

We had to bump a major version of the docker image as the base busybox image had issues with curl

```shell
# trying to install curl
/workdir $ apk add --update curl                                                        
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz             
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz        
(1/1) Installing curl (7.60.0-r1)                                                       
Executing busybox-1.25.1-r0.trigger                                                     
OK: 376 MiB in 52 packages                                                              

# Errors. Curl cannot run
/workdir $ curl                                                                         
Error relocating /usr/bin/curl: curl_mime_type: symbol not found                        
Error relocating /usr/bin/curl: curl_mime_data: symbol not found                        
Error relocating /usr/bin/curl: curl_mime_data_cb: symbol not found                     
Error relocating /usr/bin/curl: curl_mime_name: symbol not found                        
Error relocating /usr/bin/curl: curl_mime_encoder: symbol not found                     
Error relocating /usr/bin/curl: curl_mime_headers: symbol not found                     
Error relocating /usr/bin/curl: curl_mime_init: symbol not found                        
Error relocating /usr/bin/curl: curl_mime_filedata: symbol not found                    
Error relocating /usr/bin/curl: curl_mime_free: symbol not found                        
Error relocating /usr/bin/curl: curl_mime_filename: symbol not found                    
Error relocating /usr/bin/curl: curl_mime_subparts: symbol not found                    
Error relocating /usr/bin/curl: curl_mime_addpart: symbol not found                     

# We can fix the issue with:
/workdir $ apk upgrade                                                                  
(1/4) Upgrading busybox (1.25.1-r0 -> 1.25.1-r2)                                        
Executing busybox-1.25.1-r2.post-upgrade                                                
(2/4) Upgrading libcurl (7.52.1-r3 -> 7.60.0-r1)                                        
(3/4) Upgrading git (2.11.2-r0 -> 2.11.3-r0)                                            
(4/4) Upgrading openssh-client (7.4_p1-r0 -> 7.4_p1-r1)                                 
Executing busybox-1.25.1-r2.trigger                                                     
OK: 376 MiB in 52 packages                                                              
/workdir $ curl                                                                         
curl: try 'curl --help' or 'curl --manual' for more information                         
```
That's why we've bumped the docker version, hopefully it doesn't cause you any issue.